### PR TITLE
[DO NOT MERGE] JAX prototype

### DIFF
--- a/cayleypy/cayley_graph_test.py
+++ b/cayleypy/cayley_graph_test.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import scipy
 import torch
+from cryptography.hazmat.backends.openssl import backend
 
 from cayleypy import CayleyGraph
 
@@ -11,14 +12,14 @@ from cayleypy import CayleyGraph
 def _last_layer_to_str(layer):
     return set(''.join(str(int(x)) for x in state) for state in layer)
 
-
+# TODO: move to a factory that is part of the library.
 def _lrx_permutations(n):
     """Generates 3 permutations from S_N: left shift, right shift and swapping first two elements."""
     return [list(range(1, n)) + [0], [n - 1] + list(range(0, n - 1)), [1, 0] + list(range(2, n))]
 
 
-@pytest.mark.parametrize("bit_encoding", [False, True])
-def test_bfs_growth_lrx(bit_encoding: bool):
+@pytest.mark.parametrize("backend,bit_encoding", [("torch", False), ("torch", True), ("jax", True)])
+def test_bfs_growth_lrx(backend:str, bit_encoding: bool):
     # Tests growth starting from string 00..0 11..1 for even N.
     test_cases = [
         (2, [1, 1], {'10'}),
@@ -55,6 +56,12 @@ def test_bfs_growth_lrx_n40():
     result2 = graph2.bfs_growth(start_states, max_layers=5)
     assert result1.layer_sizes == result2.layer_sizes
 
+    # TODO: when implemented, add the test for JAX using generic permutation.
+
+    graph3 = CayleyGraph(_lrx_permutations(n), bit_encoding_width=6, backend="jax")
+    result3 = graph3.bfs_growth(start_states, max_layers=5)
+    assert result3.layer_sizes == result1.layer_sizes
+
 
 @pytest.mark.parametrize("bit_encoding_width", [None, 1])
 def test_bfs_growth_lrx_coset(bit_encoding_width):
@@ -85,6 +92,7 @@ def test_bfs_growth_lrx_coset(bit_encoding_width):
         assert _last_layer_to_str(result.last_layer) == expected_last_layer
 
 
+# TODO: move to a factory that is part of the library.
 def _top_spin_permutations(n):
     """Generates 3 permutations from S_N: left shift, right shift and reversing first 4 elements."""
     return [list(range(1, n)) + [0], [n - 1] + list(range(0, n - 1)), [3, 2, 1, 0] + list(range(4, n))]
@@ -120,10 +128,11 @@ BENCHMARK_RUN = os.getenv("BENCHMARK") == "1"
 
 
 @pytest.mark.skipif(not BENCHMARK_RUN, reason="benchmark")
-@pytest.mark.parametrize("benchmark_mode", ["baseline", "bit_encoded"])
-@pytest.mark.parametrize("n", [28])
+@pytest.mark.parametrize("benchmark_mode", ["baseline", "bit_encoded", "bit_encoded_jax"])
+@pytest.mark.parametrize("n", [10])
 def test_benchmark_top_spin(benchmark, benchmark_mode, n):
     start_states = torch.tensor([[0] * (n // 2) + [1] * (n // 2)])
-    bit_encoding_width = 1 if benchmark_mode == "bit_encoded" else None
-    graph = CayleyGraph(_lrx_permutations(n), bit_encoding_width=bit_encoding_width)
-    benchmark(lambda: graph.bfs_growth(start_states))
+    bit_encoding_width = 1 if "bit_encoded" in benchmark_mode else None
+    backend = "jax" if benchmark_mode=="bit_encoded_jax" else "torch"
+    graph = CayleyGraph(_lrx_permutations(n), bit_encoding_width=bit_encoding_width, backend=backend)
+    benchmark.pedantic(lambda: graph.bfs_growth(start_states), rounds=2)

--- a/cayleypy/cayley_graph_test.py
+++ b/cayleypy/cayley_graph_test.py
@@ -4,7 +4,6 @@ import os
 import pytest
 import scipy
 import torch
-from cryptography.hazmat.backends.openssl import backend
 
 from cayleypy import CayleyGraph
 

--- a/cayleypy/string_encoder_test.py
+++ b/cayleypy/string_encoder_test.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 import torch
 
+import jax.numpy as jnp
+
 from .string_encoder import StringEncoder
 
 
@@ -20,6 +22,7 @@ def test_encode_decode(code_width, n):
     assert s_encoded.shape == (num_states, int(math.ceil(code_width * n / 63)))
     assert torch.equal(s, enc.decode(s_encoded))
 
+import jax
 
 @pytest.mark.parametrize("code_width,n", [(1, 2), (1, 5), (2, 30), (10, 100)])
 def test_permutation(code_width: int, n: int):
@@ -29,5 +32,12 @@ def test_permutation(code_width: int, n: int):
     expected = torch.tensor([_apply_permutation(row, perm) for row in np.array(s)])
     enc = StringEncoder(code_width=code_width, n=n)
     perm_func = enc.implement_permutation(perm)
-    ans = enc.decode(perm_func(enc.encode(s)))
+    s_encoded = enc.encode(s)
+    ans = enc.decode(perm_func(s_encoded))
     assert torch.equal(ans, expected)
+
+    jax.config.update("jax_enable_x64", True)  # TODO: remove this.
+    perm_func_jax = enc.implement_permutation(perm, backend='jax')
+    ans2 = enc.decode(perm_func_jax(jnp.array(s_encoded, dtype=np.int64)))
+    assert torch.equal(ans2, expected)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-numpy
-torch
+numpy~=1.26
+torch~=2.6
+jax

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy~=1.26
-torch~=2.6
+numpy
+torch

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+import setuptools
+
+with open("README.md", "r", encoding='utf-8') as readme_file:
+    long_description = readme_file.read()
+
+with open('requirements.txt', 'r', encoding='utf-8') as req_file:
+    requirements = [r.strip() for r in req_file.readlines()]
+
+setuptools.setup(
+    name="cayleypy",
+    version="1.0.0",
+    author="CayleyPy Foundation",
+    description="Cayley graphs processing using GPU and pytorch",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    license='MIT',
+    url="https://github.com/iKolt/cayleypy",
+    packages=setuptools.find_packages(),
+    python_requires='>=3.10',
+    install_requires=requirements,
+)


### PR DESCRIPTION
I tried to implement support for JAX for BFS using encoded state representation.

The overall idea is:
* There are 2 backends, 'torch' and 'jax'.
* When we initialize states, we convert them to either torch.tensor or jnp.array, and then all computations are over this type, which we call BackendTensor.
* In every place where we need to do backend-specific computation, there is an if statement on backend.

I don't like this approach because:
* When I tried to run, JAX is extremely slow, like >1000x slower (???)
* To do interactive development on Kaggle, I need to wait in queue.
* All we would gain from this is time, not RAM, and our computations are RAM-bounded. In best case, all we wouldget is faster runtime when we run notebooks on Kaggle on TPU.
* The code becomes much uglier than I expected. I don't like all these if conditions.

However, let's keep this PR around as a prototype in case someone wants to explore using JAX again. I'll try to get test working to demonstarte that this is functionally correct.